### PR TITLE
FIX: Coredns v1.8.3 rbac permission on endpointslices

### DIFF
--- a/templates/addons/coredns.yaml.tpl
+++ b/templates/addons/coredns.yaml.tpl
@@ -31,6 +31,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Fix the errors on coredns v1.8.3
```
Failed to watch *v1beta1.EndpointSlice: failed to list
*v1beta1.EndpointSlice: endpointslices.discovery.k8s.io
```

Reference: https://github.com/coredns/helm/issues/9