### PR TITLE
fix: upgrade aws-pod-identity-webhook to fix issues with k8s v1.19

### DIFF
--- a/modules/extra-addons/aws-pod-identity-webhook/variables.tf
+++ b/modules/extra-addons/aws-pod-identity-webhook/variables.tf
@@ -3,7 +3,7 @@ variable "container" {
   type        = map(string)
   default = {
     repo = "quay.io/amis/aws-pod-identity-webhook"
-    tag  = "2c44edc"
+    tag  = "ed8c41f"
   }
 }
 


### PR DESCRIPTION
Fix issue:
https://github.com/aws/amazon-eks-pod-identity-webhook/issues/89