### PR TITLE
FEATURE: improve aws-pod-identity-webhook availability

### DIFF
--- a/modules/extra-addons/aws-pod-identity-webhook/main.tf
+++ b/modules/extra-addons/aws-pod-identity-webhook/main.tf
@@ -8,6 +8,7 @@ data "ignition_file" "pod_identity_webhook" {
       image                 = "${var.container["repo"]}:${var.container["tag"]}"
       service_name          = var.service_name
       namespace             = var.namespace
+      replicas              = var.replicas
       flags                 = local.webhook_flags
       ca_bundle             = base64encode(var.mutating_webhook_ca_bundle)
       tls_crt               = base64encode(var.tls_cert)

--- a/modules/extra-addons/aws-pod-identity-webhook/templates/pod-identity-webhook.yaml.tpl
+++ b/modules/extra-addons/aws-pod-identity-webhook/templates/pod-identity-webhook.yaml.tpl
@@ -47,7 +47,11 @@ metadata:
   name: ${service_name}
   namespace: ${namespace}
 spec:
-  replicas: 1
+  replicas: ${replicas}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: ${service_name}
@@ -65,6 +69,16 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
 %{ endif ~}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - ${service_name}
+            topologyKey: kubernetes.io/hostname
       serviceAccountName: ${service_name}
       containers:
       - name: ${service_name}

--- a/modules/extra-addons/aws-pod-identity-webhook/variables.tf
+++ b/modules/extra-addons/aws-pod-identity-webhook/variables.tf
@@ -19,6 +19,12 @@ variable "namespace" {
   default     = "kube-system"
 }
 
+variable "replicas" {
+  description = "The pod identity webhook deployment replicas"
+  type        = number
+  default     = 1
+}
+
 variable "located_control_plane" {
   description = "Located in control plane nodes."
   type        = bool


### PR DESCRIPTION
- Configurable `replicas` variable for pod-identity-webhook deployment.
- Add `podAntiAffinity` to prevent pod-identity-webhook pods to be scheduled on the same node.