### PR TITLE
FEATURE: expose kube-proxy metrics on 0.0.0.0:10249 by default

### DIFF
--- a/variables_defaults.tf
+++ b/variables_defaults.tf
@@ -108,9 +108,10 @@ locals {
   }, var.coredns_config)
 
   kube_proxy_config = merge({
-    bindAddress = "0.0.0.0"
-    clusterCIDR = var.pod_network_cidr
-    mode        = "iptables"
+    bindAddress        = "0.0.0.0"
+    clusterCIDR        = var.pod_network_cidr
+    metricsBindAddress = "0.0.0.0:10249"
+    mode               = "iptables"
   }, var.kube_proxy_config)
 
   oidc_config = merge({


### PR DESCRIPTION
Currently the kube-proxy metrics are exposed by default on `127.0.0.1:10249`. It makes it impossible to export kube proxy metrics to prometheus server via prometheus operator.