### PR TITLE
FIX: metricsBindAddress with port number will cause kube-proxy pod crash

### DIFF
--- a/variables_defaults.tf
+++ b/variables_defaults.tf
@@ -110,7 +110,7 @@ locals {
   kube_proxy_config = merge({
     bindAddress        = "0.0.0.0"
     clusterCIDR        = var.pod_network_cidr
-    metricsBindAddress = "0.0.0.0:10249"
+    metricsBindAddress = "0.0.0.0"
     mode               = "iptables"
   }, var.kube_proxy_config)
 


### PR DESCRIPTION
Set `metricsBindAddress` to 0.0.0.0 for all interfaces.
Ref: https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/