### PR TITLE
FEATURE: Workaround FlatCar CoreOS upgrade iptables to nftables

### DIFF
--- a/variables_defaults.tf
+++ b/variables_defaults.tf
@@ -22,7 +22,7 @@ locals {
     }
     vpc_cni = {
       repo = "quay.io/amis/amazon-k8s-cni"
-      tag  = "v1.11.0"
+      tag  = "v1.11.0-nftables"
     }
     vpc_cni_init = {
       repo = "quay.io/amis/amazon-k8s-cni-init"

--- a/variables_defaults.tf
+++ b/variables_defaults.tf
@@ -22,11 +22,11 @@ locals {
     }
     vpc_cni = {
       repo = "quay.io/amis/amazon-k8s-cni"
-      tag  = "v1.10.2"
+      tag  = "v1.11.0"
     }
     vpc_cni_init = {
       repo = "quay.io/amis/amazon-k8s-cni-init"
-      tag  = "v1.10.2"
+      tag  = "v1.11.0"
     }
     calico_node = {
       repo = "quay.io/calico/node"


### PR DESCRIPTION
Use customized amazon-k8s-cni container image to workaround [FlatCar CoreOS upgrade iptables to nftables](https://www.flatcar-linux.org/releases#release-3033.2.0), the container image refer to [amazon-vpc-cni-k8s GitHub issue](https://github.com/aws/amazon-vpc-cni-k8s/issues/1847#issuecomment-1040878745) to customize