### PR TITLE
FIX: kube-apiserver readiness probe and docker pull ecr image failed

### DIFF
--- a/modules/kubelet/files/scripts/init-configs.sh
+++ b/modules/kubelet/files/scripts/init-configs.sh
@@ -75,7 +75,7 @@ if test -f ${CSR_FILE_SRC} && ! test -f ${KUBELET_VAR_PATH}/pki/${FILE_NAME} ; t
   generate::file ${CA_CONFIG_SRC} ${CA_CONFIG_DEST}
   generate::file ${CSR_FILE_SRC} ${CSR_FILE_DEST}
 
-  sudo ${DOCKER_EXEC} run --rm \
+  ${DOCKER_EXEC} run --rm \
   -v ${KUBELET_VAR_PATH}/pki/:/tmp/pki/ \
   -v ${KUBE_ETC_PATH}/pki/:${KUBE_ETC_PATH}/pki/ \
   -e HOSTNAME=${HOSTNAME} \

--- a/modules/kubelet/files/scripts/kubelet-wrapper.sh
+++ b/modules/kubelet/files/scripts/kubelet-wrapper.sh
@@ -19,7 +19,7 @@ source /opt/kubernetes/bin/get-host-info.sh
 sudo sysctl --system
 
 set -x
-exec sudo /usr/bin/docker run --name kubelet \
+exec /usr/bin/docker run --name kubelet \
   --privileged \
   --pid host \
   --network host \

--- a/modules/kubelet/templates/services/10-kubelet.conf.tpl
+++ b/modules/kubelet/templates/services/10-kubelet.conf.tpl
@@ -1,10 +1,11 @@
 [Service]
+Environment="PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=${bootstrap_kubeconfig} --kubeconfig=${kubeconfig}"
 Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni"
 EnvironmentFile=-/etc/default/kubernetes.env
 EnvironmentFile=-/var/lib/kubelet/kubelet-flags.env
 ExecStart=
-ExecStartPre=-sudo /bin/docker rm kubelet
+ExecStartPre=-/bin/docker rm kubelet
 ExecStart=/opt/kubernetes/bin/kubelet-wrapper $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_NETWORK_ARGS $KUBELET_CLOUD_PROVIDER_ARGS $KUBELET_EXTRA_ARGS
 ExecStop=-/usr/bin/docker stop kubelet

--- a/modules/kubelet/templates/services/kubeinit-configs.service.tpl
+++ b/modules/kubelet/templates/services/kubeinit-configs.service.tpl
@@ -11,6 +11,7 @@ RemainAfterExit=true
 User=root
 Group=root
 
+Environment="PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 EnvironmentFile=-/etc/default/kubernetes.env
 ExecStart=/opt/kubernetes/bin/init-configs
 ExecStartPost=/bin/touch /opt/kubernetes/init-configs.done

--- a/scripts/init-addons.sh
+++ b/scripts/init-addons.sh
@@ -21,11 +21,11 @@ source /opt/kubernetes/bin/get-host-info.sh
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 set -x
-sudo docker run --rm \
+docker run --rm \
   -v /etc/kubernetes/admin.conf:/root/.kube/config:ro \
   --entrypoint=kubectl ${KUBECTL_IMAGE} label node ${HOSTNAME_FQDN} node-role.kubernetes.io/master="" --overwrite
 
-sudo docker run --rm \
+docker run --rm \
   -v /etc/kubernetes/admin.conf:/root/.kube/config:ro \
   -v ${ADDONS_PATH}:${ADDONS_PATH}:ro \
   --entrypoint=kubectl ${KUBECTL_IMAGE} apply -f ${ADDONS_PATH}

--- a/templates/manifests/kube-apiserver.yaml.tpl
+++ b/templates/manifests/kube-apiserver.yaml.tpl
@@ -53,6 +53,14 @@ spec:
         scheme: HTTPS
       initialDelaySeconds: 15
       timeoutSeconds: 15
+    readinessProbe:
+      failureThreshold: 2
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: ${secure_port}
+        scheme: HTTPS
+      timeoutSeconds: 3
     resources:
 %{ if resources["cpu_request"] != "" || resources["memory_request"] != "" ~}
       requests:

--- a/templates/services/kubeinit-addons.service.tpl
+++ b/templates/services/kubeinit-addons.service.tpl
@@ -6,6 +6,7 @@ After=kubelet.service
 Type=simple
 RemainAfterExit=true
 
+Environment="PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 EnvironmentFile=-/etc/default/kubernetes.env
 Environment="ADDONS_PATH=${path}"
 ExecStart=/opt/kubernetes/bin/init-addons


### PR DESCRIPTION
- feat: add readiness probe to kube-apiserver
- fix: failed to pull aws ecr images without sudo
  - Docker needs to execute `/opt/bin/docker-credential-ecr-login` to get the credentials, but `/opt/bin` is not in the systemd $PATH variable.