### PR TITLE
FEATURE: kubernetes node graceful shutdown

### DIFF
--- a/kubeconfigs.tf
+++ b/kubeconfigs.tf
@@ -23,7 +23,7 @@ module "controller_manager_kubeconfig" {
   cluster  = "kubernetes"
   context  = "system:kube-controller-manager@kubernetes"
   user     = "system:kube-controller-manager"
-  endpoint = "https://127.0.0.1:${var.apiserver_secure_port}"
+  endpoint = var.internal_endpoint
 
   certificates = {
     ca_cert     = var.certs["ca_cert"]
@@ -40,7 +40,7 @@ module "scheduler_kubeconfig" {
   cluster  = "kubernetes"
   context  = "system:kube-scheduler@kubernetes"
   user     = "system:kube-scheduler"
-  endpoint = "https://127.0.0.1:${var.apiserver_secure_port}"
+  endpoint = var.internal_endpoint
 
   certificates = {
     ca_cert     = var.certs["ca_cert"]
@@ -57,7 +57,7 @@ module "kubelet_kubeconfig" {
   cluster  = "kubernetes"
   context  = "system:kubelet@kubernetes"
   user     = "system:kubelet"
-  endpoint = "https://127.0.0.1:${var.apiserver_secure_port}"
+  endpoint = var.internal_endpoint
 
   certificates = {
     ca_cert          = var.certs["ca_cert"]

--- a/modules/kubelet/files/scripts/node-shutdown.sh
+++ b/modules/kubelet/files/scripts/node-shutdown.sh
@@ -17,7 +17,7 @@ function node_cleaning(){
 	docker run --rm \
 		-v /etc/kubernetes/kubelet.conf:/root/.kube/config:ro \
 		-v /var/lib/kubelet/pki/kubelet-client-current.pem:/var/lib/kubelet/pki/kubelet-client-current.pem:ro \
-		--entrypoint=kubectl "${KUBECTL_IMAGE}" cordon "${HOSTNAME_FQDN}" && \
+		--entrypoint=kubectl "${KUBECTL_IMAGE}" cordon "${HOSTNAME_FQDN}"
 
 	# Gracefully shutdown kubelet
 	systemctl stop kubelet.service

--- a/modules/kubelet/files/scripts/node-shutdown.sh
+++ b/modules/kubelet/files/scripts/node-shutdown.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Kubernetes Node Graceful Shutdown Script
+
+set -eu
+
+function require_ev_all() {
+	for rev in $@ ; do
+		if [[ -z "${!rev}" ]]; then
+			echo "${rev}" is not set
+			exit 1
+		fi
+	done
+}
+
+function node_cleaning(){
+	#	kubectl cordon node
+	docker run --rm \
+		-v /etc/kubernetes/kubelet.conf:/root/.kube/config:ro \
+		-v /var/lib/kubelet/pki/kubelet-client-current.pem:/var/lib/kubelet/pki/kubelet-client-current.pem:ro \
+		--entrypoint=kubectl "${KUBECTL_IMAGE}" cordon "${HOSTNAME_FQDN}" && \
+
+	# Gracefully shutdown kubelet
+	systemctl stop kubelet.service
+
+	# kubectl delete node
+	docker run --rm \
+		-v /etc/kubernetes/kubelet.conf:/root/.kube/config:ro \
+		-v /var/lib/kubelet/pki/kubelet-client-current.pem:/var/lib/kubelet/pki/kubelet-client-current.pem:ro \
+		--entrypoint=kubectl "${KUBECTL_IMAGE}" delete node "${HOSTNAME_FQDN}"
+
+	# Exit node-shutdown script to release inhibitor lock
+	exit 0
+}
+
+require_ev_all KUBECTL_IMAGE_REPO KUBECTL_IMAGE_TAG
+KUBECTL_IMAGE="${KUBECTL_IMAGE_REPO}:${KUBECTL_IMAGE_TAG}"
+source /opt/kubernetes/bin/get-host-info.sh
+
+set -x
+
+# Read PrepareForShutdown DBus signal to graceful shutdown kubelet node.
+while true; do
+	while read -r signal; do
+		case "$signal" in
+			*PrepareForShutdown*)	node_cleaning ;;
+			*)										echo "Ignore unknown signal." ;;
+		esac
+	done < <(dbus-monitor --system "type='signal', interface='org.freedesktop.login1.Manager', member='PrepareForShutdown'")
+done 

--- a/modules/kubelet/main.tf
+++ b/modules/kubelet/main.tf
@@ -74,6 +74,16 @@ data "ignition_file" "get_host_info_sh" {
   }
 }
 
+data "ignition_file" "node_shutdown_sh" {
+  path       = "${local.opt_path}/bin/node-shutdown"
+  filesystem = "root"
+  mode       = 500
+
+  content {
+    content = file("${path.module}/files/scripts/node-shutdown.sh")
+  }
+}
+
 data "ignition_file" "kubelet_wrapper_sh" {
   path       = "${local.opt_path}/bin/kubelet-wrapper"
   filesystem = "root"
@@ -135,6 +145,16 @@ data "ignition_file" "systemd_drop_in_kubelet_conf" {
   }
 }
 
+data "ignition_file" "logind_kubelet_conf" {
+  path       = "/etc/systemd/logind.conf.d/99-kubelet.conf"
+  filesystem = "root"
+  mode       = 420
+
+  content {
+    content = templatefile("${path.module}/templates/services/logind-99-kubelet.conf.tpl", {})
+  }
+}
+
 data "ignition_systemd_unit" "kubelet" {
   name    = "kubelet.service"
   enabled = true
@@ -145,4 +165,10 @@ data "ignition_systemd_unit" "kubeinit_configs" {
   name    = "kubeinit-configs.service"
   enabled = true
   content = templatefile("${path.module}/templates/services/kubeinit-configs.service.tpl", {})
+}
+
+data "ignition_systemd_unit" "kubenode_shutdown" {
+  name    = "kubenode-shutdown.service"
+  enabled = true
+  content = templatefile("${path.module}/templates/services/kubenode-shutdown.service.tpl", {})
 }

--- a/modules/kubelet/outputs.tf
+++ b/modules/kubelet/outputs.tf
@@ -2,6 +2,7 @@ output "systemd_units" {
   value = [
     data.ignition_systemd_unit.kubeinit_configs.rendered,
     data.ignition_systemd_unit.kubelet.rendered,
+    data.ignition_systemd_unit.kubenode_shutdown.rendered,
   ]
 }
 
@@ -12,12 +13,14 @@ output "files" {
       data.ignition_file.kubernetes_env.rendered,
       data.ignition_file.init_configs_sh.rendered,
       data.ignition_file.get_host_info_sh.rendered,
+      data.ignition_file.node_shutdown_sh.rendered,
       data.ignition_file.kubelet_wrapper_sh.rendered,
       data.ignition_file.kubelet_env.rendered,
       data.ignition_file.systemd_drop_in_kubelet_conf.rendered,
       data.ignition_file.kubelet_config_tpl.rendered,
       data.ignition_file.sysctl_k8s_conf.rendered,
       data.ignition_file.sysctl_max_user_watches_conf.rendered,
+      data.ignition_file.logind_kubelet_conf.rendered,
     ],
     var.bootstrap_kubeconfig_content != "" ? [
       data.ignition_file.bootstrap_kubeconfig[0].rendered,

--- a/modules/kubelet/templates/services/10-kubelet.conf.tpl
+++ b/modules/kubelet/templates/services/10-kubelet.conf.tpl
@@ -7,5 +7,5 @@ EnvironmentFile=-/etc/default/kubernetes.env
 EnvironmentFile=-/var/lib/kubelet/kubelet-flags.env
 ExecStart=
 ExecStartPre=-/bin/docker rm kubelet
-ExecStart=/opt/kubernetes/bin/kubelet-wrapper $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_NETWORK_ARGS $KUBELET_CLOUD_PROVIDER_ARGS $KUBELET_EXTRA_ARGS
-ExecStop=-/usr/bin/docker stop kubelet
+ExecStart=systemd-inhibit --what=shutdown --mode=delay /opt/kubernetes/bin/kubelet-wrapper $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_NETWORK_ARGS $KUBELET_CLOUD_PROVIDER_ARGS $KUBELET_EXTRA_ARGS
+ExecStop=/bin/bash -c "docker stop -t 60 $$(docker ps -q)"

--- a/modules/kubelet/templates/services/kubenode-shutdown.service.tpl
+++ b/modules/kubelet/templates/services/kubenode-shutdown.service.tpl
@@ -1,0 +1,13 @@
+[Unit]
+Description = Kubernetes node graceful shutdown script
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+
+Environment="PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+EnvironmentFile=-/etc/default/kubernetes.env
+ExecStart=systemd-inhibit --what=shutdown --mode=delay /opt/kubernetes/bin/node-shutdown
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/kubelet/templates/services/logind-99-kubelet.conf.tpl
+++ b/modules/kubelet/templates/services/logind-99-kubelet.conf.tpl
@@ -1,0 +1,3 @@
+# logind override
+[Login]
+InhibitDelayMaxSec=300

--- a/templates/bootstrap-token/rbac.yaml.tpl
+++ b/templates/bootstrap-token/rbac.yaml.tpl
@@ -61,3 +61,28 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:nodes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubelet:delete-nodes
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelet:node-gracaful-shutdown
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubelet:delete-nodes
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes


### PR DESCRIPTION
**How does it work?**
1. Running `kubelet.service` with an inhibitor lock (delay power-off event).
2. Running `kubenode-shutdown.service` to monitor D-Bus signal, and request an inhibitor lock to prevent power-off event interrupt `node_cleaning()`.
3. When `kubenode-shutdown.service` received `PrepareForShutdown` signal, it will run `node_cleaning()` function.
    1. Cordon the worker node.
    2. Stop all containers and release `kubelet` inhibitor lock after `kubelet` container is stopped.
    3. After all containers are stopped, it will delete the worker node from cluster.
    4. Release `kubenode-shutdown` inhibitor lock.
5. Continue the power-off procedure.

Ref: https://kubernetes.io/blog/2021/04/21/graceful-node-shutdown-beta/