### PR TITLE
FIX: remove cgroupv1 mount in docker exec command

### DIFF
--- a/modules/kubelet/files/scripts/kubelet-wrapper.sh
+++ b/modules/kubelet/files/scripts/kubelet-wrapper.sh
@@ -33,7 +33,6 @@ exec /usr/bin/docker run --name kubelet \
   --volume /lib/modules:/lib/modules:ro \
   --volume /run:/run \
   --volume /sys/fs/cgroup:/sys/fs/cgroup \
-  --volume /sys/fs/cgroup/systemd:/sys/fs/cgroup/systemd \
   --volume /usr/share/ca-certificates:/usr/share/ca-certificates:ro \
   --volume /var/lib/containerd/:/var/lib/containerd \
   --volume /var/lib/calico:/var/lib/calico:ro \


### PR DESCRIPTION
Mount `/sys/fs/cgroup/systemd` into kubelet docker container will cause error log flooding.

It make cadvisor consider "systemd" as a container which cause partial failure when calling `ContainerInfoV2` function
```
E0921 08:28:54.048168    4562 cadvisor_stats_provider.go:442] "Partial failure issuing cadvisor.ContainerInfoV2" err="partial failures: [\"/systemd\": RecentStats: unable to find data in memory cache]"
E0921 08:28:56.115647    4562 cadvisor_stats_provider.go:442] "Partial failure issuing cadvisor.ContainerInfoV2" err="partial failures: [\"/systemd\": RecentStats: unable to find data in memory cache]"
E0921 08:29:06.219498    4562 cadvisor_stats_provider.go:442] "Partial failure issuing cadvisor.ContainerInfoV2" err="partial failures: [\"/systemd\": RecentStats: unable to find data in memory cache]"
```