### PR TITLE
DOCS: update How to generate Cilium manifests

### DIFF
--- a/templates/network-plugins/cilium/README.md
+++ b/templates/network-plugins/cilium/README.md
@@ -3,6 +3,7 @@
 1. `helm repo add cilium https://helm.cilium.io/`
 1. `helm pull cilium/cilium --version 1.16.1 --untar`
 1. `mv cilium/values.yaml vxlan-values.yaml`
-1. `rm -r cilium/`
+1. `rm cilium/values.schema.json` 
 1. Update vxlan-values.yaml, make sure the template variables have not been replaced.
-1. `helm template cilium cilium/cilium --version 1.16.1 -n kube-system -f vxlan-values.yaml | sed 's/{BIN_PATH}/BIN_PATH/g' > cilium-vxlan.yaml.tpl`
+1. `helm template cilium ./cilium --version 1.16.1 -n kube-system -f vxlan-values.yaml | sed 's/{BIN_PATH}/BIN_PATH/g' > cilium-vxlan.yaml.tpl`
+1. `rm -r cilium/`


### PR DESCRIPTION
因為後來 cilium 多了`values.schema.json` 會讓我們 helm template 多了 
`debug.enabled: Invalid type. Expected: boolean, given: string` 這個 error
想要改成透過下載的 cilium 去做 helm template