### PR TITLE
FEATURE: add AWS VPC CNI IP allocation strategy variables

### DIFF
--- a/network-plugins.tf
+++ b/network-plugins.tf
@@ -17,6 +17,12 @@ data "ignition_file" "aws_vpc_cni_yaml" {
       enable_eni_prefix     = var.enable_eni_prefix
       enable_network_policy = var.enable_network_policy
       external_snat         = var.external_snat
+      # IP Allocation Strategy
+      warm_eni_target       = var.ip_allocation_strategy.warm_eni_target
+      warm_prefix_target    = var.ip_allocation_strategy.warm_prefix_target
+      warm_ip_target        = var.ip_allocation_strategy.warm_ip_target
+      minimum_ip_target     = var.ip_allocation_strategy.minimum_ip_target
+      # log level
       log_level             = var.log_level["aws_vpc_cni"]
     })
     mime = "text/yaml"

--- a/network-plugins.tf
+++ b/network-plugins.tf
@@ -17,11 +17,11 @@ data "ignition_file" "aws_vpc_cni_yaml" {
       enable_eni_prefix     = var.enable_eni_prefix
       enable_network_policy = var.enable_network_policy
       external_snat         = var.external_snat
-      # IP Allocation Strategy
-      warm_eni_target       = var.ip_allocation_strategy.warm_eni_target
-      warm_prefix_target    = var.ip_allocation_strategy.warm_prefix_target
-      warm_ip_target        = var.ip_allocation_strategy.warm_ip_target
-      minimum_ip_target     = var.ip_allocation_strategy.minimum_ip_target
+      # IP Allocation Strategy (Cannot be null, so we need to convert to empty string)
+      warm_eni_target       = var.ip_allocation_strategy.warm_eni_target == null ? "" : var.ip_allocation_strategy.warm_eni_target
+      warm_prefix_target    = var.ip_allocation_strategy.warm_prefix_target == null ? "" : var.ip_allocation_strategy.warm_prefix_target
+      warm_ip_target        = var.ip_allocation_strategy.warm_ip_target == null ? "" : var.ip_allocation_strategy.warm_ip_target
+      minimum_ip_target     = var.ip_allocation_strategy.minimum_ip_target == null ? "" : var.ip_allocation_strategy.minimum_ip_target
       # log level
       log_level             = var.log_level["aws_vpc_cni"]
     })

--- a/templates/network-plugins/amazon-vpc/aws-vpc-cni.yaml.tpl
+++ b/templates/network-plugins/amazon-vpc/aws-vpc-cni.yaml.tpl
@@ -506,22 +506,22 @@ spec:
               value: "standard"
             - name: VPC_CNI_VERSION
               value: "${cni_version}"
-            {% if warm_eni_target != "" %}
+            %{ if warm_eni_target != "" }
             - name: WARM_ENI_TARGET
               value: "${warm_eni_target}"
-            {% endif %}
-            {% if warm_prefix_target != "" %}
+            %{ endif }
+            %{ if warm_prefix_target != "" }
             - name: WARM_PREFIX_TARGET
               value: "${warm_prefix_target}"
-            {% endif %}
-            {% if warm_ip_target != "" %}
+            %{ endif }
+            %{ if warm_ip_target != "" }
             - name: WARM_IP_TARGET
               value: "${warm_ip_target}"
-            {% endif %}
-            {% if minimum_ip_target != "" %}
+            %{ endif }
+            %{ if minimum_ip_target != "" }
             - name: MINIMUM_IP_TARGET
               value: "${minimum_ip_target}"
-            {% endif %}
+            %{ endif }
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/templates/network-plugins/amazon-vpc/aws-vpc-cni.yaml.tpl
+++ b/templates/network-plugins/amazon-vpc/aws-vpc-cni.yaml.tpl
@@ -506,10 +506,22 @@ spec:
               value: "standard"
             - name: VPC_CNI_VERSION
               value: "${cni_version}"
+            {% if warm_eni_target != null %}
             - name: WARM_ENI_TARGET
-              value: "1"
+              value: "${warm_eni_target}"
+            {% endif %}
+            {% if warm_prefix_target != null %}
             - name: WARM_PREFIX_TARGET
-              value: "1"
+              value: "${warm_prefix_target}"
+            {% endif %}
+            {% if warm_ip_target != null %}
+            - name: WARM_IP_TARGET
+              value: "${warm_ip_target}"
+            {% endif %}
+            {% if minimum_ip_target != null %}
+            - name: MINIMUM_IP_TARGET
+              value: "${minimum_ip_target}"
+            {% endif %}
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/templates/network-plugins/amazon-vpc/aws-vpc-cni.yaml.tpl
+++ b/templates/network-plugins/amazon-vpc/aws-vpc-cni.yaml.tpl
@@ -506,19 +506,19 @@ spec:
               value: "standard"
             - name: VPC_CNI_VERSION
               value: "${cni_version}"
-            {% if warm_eni_target != null %}
+            {% if warm_eni_target != "" %}
             - name: WARM_ENI_TARGET
               value: "${warm_eni_target}"
             {% endif %}
-            {% if warm_prefix_target != null %}
+            {% if warm_prefix_target != "" %}
             - name: WARM_PREFIX_TARGET
               value: "${warm_prefix_target}"
             {% endif %}
-            {% if warm_ip_target != null %}
+            {% if warm_ip_target != "" %}
             - name: WARM_IP_TARGET
               value: "${warm_ip_target}"
             {% endif %}
-            {% if minimum_ip_target != null %}
+            {% if minimum_ip_target != "" %}
             - name: MINIMUM_IP_TARGET
               value: "${minimum_ip_target}"
             {% endif %}

--- a/variables.tf
+++ b/variables.tf
@@ -255,3 +255,22 @@ variable "log_level" {
     kubelet                      = optional(string, "2")     # 2: Info, 3: Extended Info, 4: Debug, 5: Trace
   })
 }
+
+variable "ip_allocation_strategy" {
+  description = "The IP allocation strategy of AWS VPC CNI, Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md"
+  type        = object({
+    warm_eni_target = optional(string, null)
+    warm_prefix_target = optional(string, null)
+    warm_ip_target = optional(string, null)
+    minimum_ip_target = optional(string, null)
+  })
+  # When enable_eni_prefix is true, prefer to use warm_ip_target and minimum_ip_target to allocate IP addresses
+  # It can prevent the CNI from keeping an entire excess prefix attached to the node.
+  # Ref: https://docs.aws.amazon.com/eks/latest/best-practices/prefix-mode-linux.html
+  default     = {
+    warm_eni_target = null
+    warm_prefix_target = null
+    warm_ip_target = "3"
+    minimum_ip_target = "5"
+  }
+}


### PR DESCRIPTION
- Introduced new variable `ip_allocation_strategy` to manage IP allocation settings.
- Updated `network-plugins.tf` to utilize the new allocation strategy variables.
- Modified `aws-vpc-cni.yaml.tpl` to conditionally set warm ENI, prefix, and IP targets based on the new variables.